### PR TITLE
Log gas diff for operations in `_postSimulation`

### DIFF
--- a/src/Simulator.sol
+++ b/src/Simulator.sol
@@ -21,6 +21,8 @@ import {
 } from "./lib/Vm.sol";
 import { ERC4337SpecsParser } from "./SpecsParser.sol";
 
+import { console } from "forge-std/console.sol";
+
 /**
  * @title Simulator
  * @author kopy-kat
@@ -161,11 +163,15 @@ library Simulator {
      * @param userOpDetails The UserOperationDetails to validate
      */
     function _postSimulation(UserOperationDetails memory userOpDetails) internal {
+        uint256 preGas = gasleft();
         // Get the recorded opcodes
         VmSafe.DebugStep[] memory debugTrace = stopAndReturnDebugTraceRecording();
+        console.log("Gas used by stopAndReturnDebugTraceRecording", preGas - gasleft());
 
+        preGas = gasleft();
         // Validate the ERC-4337 rules
         ERC4337SpecsParser.parseValidation(userOpDetails, debugTrace);
+        console.log("Gas used by parseValidation", preGas - gasleft());
 
         // Stop (and remove) recording mapping accesses
         stopMappingRecording();

--- a/src/SpecsParser.sol
+++ b/src/SpecsParser.sol
@@ -10,6 +10,8 @@ import {
 import { VmSafe } from "forge-std/Vm.sol";
 import { getLabel, getMappingKeyAndParentOf } from "./lib/Vm.sol";
 
+import { console } from "forge-std/console.sol";
+
 /**
  * @title ERC4337SpecsParser
  * @author kopy-kat
@@ -61,38 +63,54 @@ library ERC4337SpecsParser {
     )
         internal
     {
+        uint256 preGas = gasleft();
         // Get entities for the userOp
         Entities memory entities = getEntities(userOpDetails);
+        console.log("Gas used by getEntities", preGas - gasleft());
 
+        preGas = gasleft();
         // Filter debug trace to get the debug steps for the userOp and paymasterUserOp
         (
             VmSafe.DebugStep[] memory filteredUserOpSteps,
             VmSafe.DebugStep[] memory filteredPaymasterUserOpSteps
         ) = filterDebugTrace(debugTrace, entities, userOpDetails.entryPoint);
+        console.log("Gas used by filterDebugTrace", preGas - gasleft());
 
+        preGas = gasleft();
         // Validate banned opcodes for the userOp and paymasterUserOp
         validateBannedOpcodes(filteredUserOpSteps, entities);
         validateBannedOpcodes(filteredPaymasterUserOpSteps, entities);
+        console.log("Gas used by validateBannedOpcodes", preGas - gasleft());
 
+        preGas = gasleft();
         // Validate there are not out of gas errors for the userOp and paymasterUserOp
         validateOutOfGas(filteredUserOpSteps);
         validateOutOfGas(filteredPaymasterUserOpSteps);
+        console.log("Gas used by validateOutOfGas", preGas - gasleft());
 
+        preGas = gasleft();
         // Validate banned storage locations
         validateBannedStorageLocations(filteredUserOpSteps, entities, userOpDetails);
         validateBannedStorageLocations(filteredPaymasterUserOpSteps, entities, userOpDetails);
+        console.log("Gas used by validateBannedStorageLocations", preGas - gasleft());
 
+        preGas = gasleft();
         // Validate calls using filtered steps
         validateCalls(filteredUserOpSteps, entities, userOpDetails.entryPoint);
         validateCalls(filteredPaymasterUserOpSteps, entities, userOpDetails.entryPoint);
+        console.log("Gas used by validateCalls", preGas - gasleft());
 
+        preGas = gasleft();
         // Validate ext opcodes using filtered steps
         validateExtOpcodes(filteredUserOpSteps, entities);
         validateExtOpcodes(filteredPaymasterUserOpSteps, entities);
+        console.log("Gas used by validateExtOpcodes", preGas - gasleft());
 
+        preGas = gasleft();
         // Validate create using filtered steps
         validateCreate(filteredUserOpSteps, entities, userOpDetails);
         validateCreate(filteredPaymasterUserOpSteps, entities, userOpDetails);
+        console.log("Gas used by validateCreate", preGas - gasleft());
     }
 
     /**

--- a/src/lib/Vm.sol
+++ b/src/lib/Vm.sol
@@ -44,3 +44,11 @@ function startDebugTraceRecording() {
 function stopAndReturnDebugTraceRecording() returns (VmSafe.DebugStep[] memory steps) {
     return Vm(VM_ADDR).stopAndReturnDebugTraceRecording();
 }
+
+function pauseGasMetering() {
+    Vm(VM_ADDR).pauseGasMetering();
+}
+
+function resumeGasMetering() {
+    Vm(VM_ADDR).resumeGasMetering();
+}


### PR DESCRIPTION
```shell
> forge test -vvvv --mt testSimulate
Ran 1 test for test/SimulatorV060.t.sol:SimulatorTest
[PASS] testSimulate() (gas: 122687982)
Logs:
  Gas used by stopAndReturnDebugTraceRecording 48967003
  // Below are operations in `parseValidation`
  Gas used by getEntities 40063
  Gas used by filterDebugTrace 70460661
  Gas used by validateBannedOpcodes 1094331
  Gas used by validateOutOfGas 211015
  Gas used by validateBannedStorageLocations 543206
  Gas used by validateCalls 487053
  Gas used by validateExtOpcodes 410799
  Gas used by validateCreate 226283
  // Total gas used by `parseValidation`: 73523105
```